### PR TITLE
Enhancement: Run tests on PHP 8.1

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -70,6 +70,7 @@ jobs:
       matrix:
         php-version:
           - "8.0"
+          - "8.1"
 
         dependencies:
           - "locked"


### PR DESCRIPTION
This pull request

- [x] runs tests on PHP 8.1

Follows #3.

💁‍♂️ By using a separate job, we can easily expand the build matrix for that job: it does not make sense to run coding-standards on PHP 8.0 and PHP 8.1, but it makes sense to run tests on PHP 8.0 and PHP 8.1 (and of course more PHP versions when desired):

<img width="1422" alt="CleanShot 2023-09-13 at 10 07 59@2x" src="https://github.com/tillmannschiffler/simplequeue/assets/605483/562c0280-cca8-45ae-b28a-e4d639e1105d">
