### PR TITLE
Fix jobType handling in JobReader and Json

### DIFF
--- a/src/Infrastructure/JobReader.php
+++ b/src/Infrastructure/JobReader.php
@@ -88,7 +88,7 @@ class JobReader
 
         return new Job(
             Uuid::fromString($json->getJobId()),
-            JobType::fromString('sample'),
+            JobType::fromString($json->getJobType()),
             JobPayload::fromString($json->getJobPayload())
         );
     }

--- a/src/Infrastructure/Json.php
+++ b/src/Infrastructure/Json.php
@@ -27,32 +27,45 @@ class Json
 
     private function ensureJsonIsValid(string $possibleJson): void
     {
-        $decodetContent = json_decode($possibleJson);
+        $decodedContent = json_decode($possibleJson);
 
-        if (is_null($decodetContent)) {
+        if (is_null($decodedContent)) {
             throw new JobInfrastructureException(json_last_error_msg());
         }
 
-        if (! isset($decodetContent->jobId)) {
+        if (! isset($decodedContent->jobId)) {
             throw new JobInfrastructureException('Missing job id in job file.');
         }
 
-        if (! isset($decodetContent->jobPayload)) {
-            throw new JobInfrastructureException('Missing payload id in job file.');
+        if (! isset($decodedContent->jobType)) {
+            throw new JobInfrastructureException('Missing job type in job file.');
         }
 
-        if (! is_string($decodetContent->jobId)) {
+        if (! isset($decodedContent->jobPayload)) {
+            throw new JobInfrastructureException('Missing payload in job file.');
+        }
+
+        if (! is_string($decodedContent->jobId)) {
             throw new JobInfrastructureException('job id is not a string.');
         }
 
-        if (! is_string($decodetContent->jobPayload)) {
-            throw new JobInfrastructureException('jobpayload is not a string.');
+        if (! is_string($decodedContent->jobType)) {
+            throw new JobInfrastructureException('job type is not a string.');
+        }
+
+        if (! is_string($decodedContent->jobPayload)) {
+            throw new JobInfrastructureException('job payload is not a string.');
         }
     }
 
     public function getJobId(): string
     {
         return $this->data->jobId;
+    }
+
+    public function getJobType(): string
+    {
+        return $this->data->jobType;
     }
 
     public function getJobPayload(): string

--- a/src/Job/Job.php
+++ b/src/Job/Job.php
@@ -41,6 +41,7 @@ class Job
     {
         return Json::encode([
             'jobId' => $this->jobId->toString(),
+            'jobType' => $this->jobType->toString(),
             'jobPayload' => $this->jobPayload->toString(),
         ]);
     }

--- a/tests/unit/Infrastructure/JobReaderTest.php
+++ b/tests/unit/Infrastructure/JobReaderTest.php
@@ -9,7 +9,7 @@ use simpleQueue\Infrastructure\JobReader;
 /**
  * @covers \simpleQueue\Infrastructure\JobReader
  */
-class JobreaderTest extends TestCase
+class JobReaderTest extends TestCase
 {
     public function testCanCreate(): void
     {

--- a/tests/unit/Infrastructure/JsonTest.php
+++ b/tests/unit/Infrastructure/JsonTest.php
@@ -31,6 +31,7 @@ class JsonTest extends TestCase
             Json::class,
             Json::fromString(json_encode([
                 'jobId' => '1',
+                'jobType' => 'bar',
                 'jobPayload' => 'foo',
             ]))
         );
@@ -40,10 +41,12 @@ class JsonTest extends TestCase
     {
         $job = Json::fromString(json_encode([
             'jobId' => '1',
+            'jobType' => 'bar',
             'jobPayload' => 'foo',
         ]));
 
         $this->assertEquals('1', $job->getJobId());
+        $this->assertEquals('bar', $job->getJobType());
         $this->assertEquals('foo', $job->getJobPayload());
     }
 
@@ -57,15 +60,26 @@ class JsonTest extends TestCase
     {
         $this->expectException(JobInfrastructureException::class);
         Json::fromString(json_encode([
+            'jobType' => 'bar',
             'jobPayload' => 'foo',
         ]));
     }
 
-    public function testCanThrowWithInvalidJobpayload(): void
+    public function testCanThrowWithInvalidJobType(): void
     {
         $this->expectException(JobInfrastructureException::class);
         Json::fromString(json_encode([
             'jobId' => '1',
+            'jobPayload' => 'foo',
+        ]));
+    }
+
+    public function testCanThrowWithInvalidJobPayload(): void
+    {
+        $this->expectException(JobInfrastructureException::class);
+        Json::fromString(json_encode([
+            'jobId' => '1',
+            'jobType' => 'bar',
         ]));
     }
 
@@ -74,6 +88,17 @@ class JsonTest extends TestCase
         $this->expectException(JobInfrastructureException::class);
         Json::fromString(json_encode([
             'jobId' => 1,
+            'jobType' => 'bar',
+            'jobPayload' => 'foo',
+        ]));
+    }
+
+    public function testCanThrowWithJobTypeNotBeeingAString(): void
+    {
+        $this->expectException(JobInfrastructureException::class);
+        Json::fromString(json_encode([
+            'jobId' => '1',
+            'jobType' => 2,
             'jobPayload' => 'foo',
         ]));
     }
@@ -83,6 +108,7 @@ class JsonTest extends TestCase
         $this->expectException(JobInfrastructureException::class);
         Json::fromString(json_encode([
             'jobId' => '1',
+            'jobType' => 'bar',
             'jobPayload' => 0,
         ]));
     }


### PR DESCRIPTION
This PR performs the following changes:
1. Replace the hardcoded `'sample'` for `JobType::fromString()` in `JobReader::read()` with the correct property;
2. Update the `Json::ensureJsonIsValid()` method to also validate `jobType`;
3. Add the `Json::getJobType()` method;
4. Update the `Job::toJson()` method to include the `jobType` property;
5. Update tests accordingly.