### PR TITLE
Make Event::getDateTimeImmutable() uniform throughout events

### DIFF
--- a/src/Event/Event.php
+++ b/src/Event/Event.php
@@ -6,4 +6,5 @@ namespace simpleQueue\Event;
 
 interface Event
 {
+    public function getDateTimeImmutable(): \DateTimeImmutable;
 }

--- a/src/Event/JobOutput.php
+++ b/src/Event/JobOutput.php
@@ -8,14 +8,14 @@ class JobOutput implements Event
 {
     private Job $job;
 
-    private string $joboutput;
+    private string $jobOutput;
 
     private \DateTimeImmutable $dateTimeImmutable;
 
-    public function __construct(Job $job, string $joboutput, \DateTimeImmutable $dateTimeImmutable)
+    public function __construct(Job $job, string $jobOutput, \DateTimeImmutable $dateTimeImmutable)
     {
         $this->job = $job;
-        $this->joboutput = $joboutput;
+        $this->jobOutput = $jobOutput;
         $this->dateTimeImmutable = $dateTimeImmutable;
     }
 
@@ -24,8 +24,13 @@ class JobOutput implements Event
         return $this->job;
     }
 
-    public function getJoboutput(): string
+    public function getJobOutput(): string
     {
-        return $this->joboutput;
+        return $this->jobOutput;
+    }
+
+    public function getDateTimeImmutable(): \DateTimeImmutable
+    {
+        return $this->dateTimeImmutable;
     }
 }


### PR DESCRIPTION
This PR performs the following changes:
1. Promote `getDateTimeImmutable()` method to `Event` interface;
2. Fix `JobOutput` to fully adhere to `Event` interface.

**Note** although the latest release of *simplequeue* is in 0.x - meaning its API is not stable yet -, item 1 breaks BC as it changes the `Event` contract.