### PR TITLE
Make queue diretory configurable

### DIFF
--- a/src/Configuration/Configuration.php
+++ b/src/Configuration/Configuration.php
@@ -8,6 +8,17 @@ use simpleQueue\Infrastructure\Directory;
 
 class Configuration
 {
+    protected string $basePath;
+
+    public function __construct(string $basePath = null)
+    {
+        if ($basePath === null) {
+            $basePath = dirname(__DIR__, 2);
+        }
+
+        $this->basePath = $basePath;
+    }
+
     public function getMaxForkChilds(): int
     {
         return 5;
@@ -15,21 +26,21 @@ class Configuration
 
     public function getInboxDirectory(): Directory
     {
-        return Directory::fromString(__DIR__.'/../../queue/inbox');
+        return Directory::fromString($this->basePath.'/queue/inbox');
     }
 
     public function getFinishedDirectory(): Directory
     {
-        return Directory::fromString(__DIR__.'/../../queue/finished');
+        return Directory::fromString($this->basePath.'/queue/finished');
     }
 
     public function getFailedDirectory(): Directory
     {
-        return Directory::fromString(__DIR__.'/../../queue/failed');
+        return Directory::fromString($this->basePath.'/queue/failed');
     }
 
     public function getProgressDirectory(): Directory
     {
-        return Directory::fromString(__DIR__.'/../../queue/progress');
+        return Directory::fromString($this->basePath.'/queue/progress');
     }
 }


### PR DESCRIPTION
This PR performs the following changes:
1. Add a new (`string $basePath`) constructor parameter to `Configure`;
2. Keep the previous default behavior if `$basePath` is not set.