### PR TITLE
Replace Uuid with JobId in Job method signatures and return types

### DIFF
--- a/src/Factory.php
+++ b/src/Factory.php
@@ -15,6 +15,7 @@ use simpleQueue\Infrastructure\JobReader;
 use simpleQueue\Infrastructure\JobWriter;
 use simpleQueue\Infrastructure\Uuid;
 use simpleQueue\Job\Job;
+use simpleQueue\Job\JobId;
 use simpleQueue\Job\JobPayload;
 use simpleQueue\Job\JobType;
 use simpleQueue\Job\ProcessorLocator;
@@ -71,7 +72,7 @@ class Factory
     public function createJob(JobType $jobType, JobPayload $jobPayload): Job
     {
         return new Job(
-            Uuid::create(),
+            JobId::fromString(Uuid::create()->toString()),
             $jobType,
             $jobPayload
         );

--- a/src/Infrastructure/JobReader.php
+++ b/src/Infrastructure/JobReader.php
@@ -6,6 +6,7 @@ namespace simpleQueue\Infrastructure;
 
 use simpleQueue\Job\Job;
 use simpleQueue\Job\JobCollection;
+use simpleQueue\Job\JobId;
 use simpleQueue\Job\JobPayload;
 use simpleQueue\Job\JobType;
 
@@ -87,7 +88,7 @@ class JobReader
         $json = Json::fromString($content);
 
         return new Job(
-            Uuid::fromString($json->getJobId()),
+            JobId::fromString($json->getJobId()),
             JobType::fromString($json->getJobType()),
             JobPayload::fromString($json->getJobPayload())
         );

--- a/src/Job/Job.php
+++ b/src/Job/Job.php
@@ -5,17 +5,16 @@ declare(strict_types=1);
 namespace simpleQueue\Job;
 
 use simpleQueue\Infrastructure\Json;
-use simpleQueue\Infrastructure\Uuid;
 
 class Job
 {
-    private Uuid $jobId;
+    private JobId $jobId;
 
     private JobPayload $jobPayload;
 
     private JobType $jobType;
 
-    public function __construct(Uuid $jobId, JobType $jobType, JobPayload $jobPayload)
+    public function __construct(JobId $jobId, JobType $jobType, JobPayload $jobPayload)
     {
         $this->jobId = $jobId;
         $this->jobPayload = $jobPayload;
@@ -27,7 +26,7 @@ class Job
         return $this->jobType;
     }
 
-    public function getJobId(): Uuid
+    public function getJobId(): JobId
     {
         return $this->jobId;
     }

--- a/tests/unit/Job/JobTest.php
+++ b/tests/unit/Job/JobTest.php
@@ -3,8 +3,8 @@
 namespace unit\Job;
 
 use PHPUnit\Framework\TestCase;
-use simpleQueue\Infrastructure\Uuid;
 use simpleQueue\Job\Job;
+use simpleQueue\Job\JobId;
 use simpleQueue\Job\JobPayload;
 use simpleQueue\Job\JobType;
 
@@ -15,14 +15,14 @@ class JobTest extends TestCase
 {
     public function testCanCreate(): void
     {
-        $uuidMock = $this->createMock(Uuid::class);
+        $jobIdMock = $this->createMock(JobId::class);
         $jobTypeMock = $this->createMock(JobType::class);
         $jobTypePayloadMock = $this->createMock(JobPayload::class);
 
         $this->assertInstanceOf(
             Job::class,
             new Job(
-                $uuidMock,
+                $jobIdMock,
                 $jobTypeMock,
                 $jobTypePayloadMock
             )
@@ -31,18 +31,18 @@ class JobTest extends TestCase
 
     public function testCanRetrieveValueObjects(): void
     {
-        $uuidMock = $this->createMock(Uuid::class);
+        $jobIdMock = $this->createMock(JobId::class);
         $jobTypeMock = $this->createMock(JobType::class);
         $jobTypePayloadMock = $this->createMock(JobPayload::class);
 
         $job = new Job(
-            $uuidMock,
+            $jobIdMock,
             $jobTypeMock,
             $jobTypePayloadMock
         );
 
         $this->assertInstanceOf(
-            Uuid::class,
+            JobId::class,
             $job->getJobId()
         );
 


### PR DESCRIPTION
This PR performs the following changes:
1. Wrap `Uuid` in a `JobId` in `Factory::createJob()`;
2. Replace `Uuid` with `JobId` in `JobReader::read()`;
3. Replace `Uuid` with `JobId` in `Job::__construct() and `Job::getJobId()`;

Rationale: using `JobId`, the user is capable of using a different random identifier generator. Besides that it follows the same principle behind `JobType` and `JobPayload` as arguments and properties of `Job`.

Note: I'd prefer if `JobId`, `JobType` and `JobPayload` were changed to be interfaces rather than concrete implementations, thus allowing custom implementation. I'd also ship a simple concrete implementation (the ones that already exist), so it works without extra effort, but allows extension/customization. - Thoughts?