### PR TITLE
Refactor JobCollection

### DIFF
--- a/src/Infrastructure/ForkingProcessingStrategy.php
+++ b/src/Infrastructure/ForkingProcessingStrategy.php
@@ -5,8 +5,9 @@ declare(strict_types=1);
 namespace simpleQueue\Infrastructure;
 
 use simpleQueue\Event\LogEmitter;
-use simpleQueue\Job\JobCollection;
+use simpleQueue\Job\Job;
 use simpleQueue\Job\ProcessingStrategy;
+use Traversable;
 
 class ForkingProcessingStrategy implements ProcessingStrategy
 {
@@ -23,11 +24,14 @@ class ForkingProcessingStrategy implements ProcessingStrategy
         $this->logEmitter = $logEmitter;
     }
 
-    public function process(JobCollection $jobs): void
+    /**
+     * @param  Traversable<Job>  $jobs
+     */
+    public function process(Traversable $jobs): void
     {
         $pidList = [];
         $joblist = [];
-        foreach ($jobs->all() as $job) {
+        foreach ($jobs as $job) {
             while (count($pidList) === $this->maxForks) {
                 foreach ($pidList as $pos => $pId) {
                     $code = pcntl_waitpid($pId, $status, WNOHANG);

--- a/src/Infrastructure/SingleProcessingStrategy.php
+++ b/src/Infrastructure/SingleProcessingStrategy.php
@@ -4,8 +4,9 @@ declare(strict_types=1);
 
 namespace simpleQueue\Infrastructure;
 
-use simpleQueue\Job\JobCollection;
+use simpleQueue\Job\Job;
 use simpleQueue\Job\ProcessingStrategy;
+use Traversable;
 
 class SingleProcessingStrategy implements ProcessingStrategy
 {
@@ -16,9 +17,12 @@ class SingleProcessingStrategy implements ProcessingStrategy
         $this->executor = $executor;
     }
 
-    public function process(JobCollection $jobs): void
+    /**
+     * @param  Traversable<Job>  $jobs
+     */
+    public function process(Traversable $jobs): void
     {
-        foreach ($jobs->all() as $job) {
+        foreach ($jobs as $job) {
             $this->executor->process($job);
         }
     }

--- a/src/Job/JobCollection.php
+++ b/src/Job/JobCollection.php
@@ -4,11 +4,18 @@ declare(strict_types=1);
 
 namespace simpleQueue\Job;
 
-class JobCollection
+use ArrayIterator;
+use IteratorAggregate;
+use Traversable;
+
+/**
+ * @template-implements IteratorAggregate<Job>
+ */
+class JobCollection implements IteratorAggregate
 {
     private array $items = [];
 
-    public function add(Job $job)
+    public function add(Job $job): void
     {
         $this->items[] = $job;
     }
@@ -19,5 +26,13 @@ class JobCollection
     public function all(): array
     {
         return $this->items;
+    }
+
+    /**
+     * @return Traversable<Job>
+     */
+    public function getIterator(): Traversable
+    {
+        return new ArrayIterator($this->items);
     }
 }

--- a/src/Job/ProcessingStrategy.php
+++ b/src/Job/ProcessingStrategy.php
@@ -4,7 +4,12 @@ declare(strict_types=1);
 
 namespace simpleQueue\Job;
 
+use Traversable;
+
 interface ProcessingStrategy
 {
-    public function process(JobCollection $jobs): void;
+    /**
+     * @param  Traversable<Job>  $jobs
+     */
+    public function process(Traversable $jobs): void;
 }

--- a/tests/unit/Job/JobCollectionTest.php
+++ b/tests/unit/Job/JobCollectionTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+use simpleQueue\Job\Job;
+use simpleQueue\Job\JobCollection;
+
+class JobCollectionTest extends TestCase
+{
+    public function testIteration(): void
+    {
+        $job1 = $this->createMock(Job::class);
+        $job2 = $this->createMock(Job::class);
+
+        $collection = new JobCollection();
+        $collection->add($job1);
+        $collection->add($job2);
+
+        $jobs = [];
+
+        // ensure iteration works
+        foreach ($collection as $job) {
+            $jobs[] = $job;
+        }
+
+        // ensure iteration gives the correct values and order
+        static::assertCount(2, $jobs);
+        static::assertSame([$job1, $job2], $jobs);
+    }
+}


### PR DESCRIPTION
* Make the collection itself iterable.
* In methods that took a JobCollection as parameter, use a more liberal `Traversable<Job>` instead. This allows using other, compatible types as well, in particular generators.
