### PR TITLE
Fix deprecated code

### DIFF
--- a/src/Configuration/Configuration.php
+++ b/src/Configuration/Configuration.php
@@ -10,7 +10,7 @@ class Configuration
 {
     protected string $basePath;
 
-    public function __construct(string $basePath = null)
+    public function __construct(?string $basePath = null)
     {
         if ($basePath === null) {
             $basePath = dirname(__DIR__, 2);


### PR DESCRIPTION
PHPUnit 10 running PHP 8.4 complains about it:

    simpleQueue\Configuration\Configuration::__construct():
    Implicitly marking parameter $basePath as nullable is deprecated,
    the explicit nullable type must be used instead